### PR TITLE
Fix typo in the gazpar.cfg template name

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Faites de même avec:
 
 - requirements.txt
 
-- gazpar_model.cfg
+- gazpar_modele.cfg
 
 Rendre gazpar_ha.sh exécutable:
 


### PR DESCRIPTION
Cette PR fixe juste une toute petite typo sur le `gazpar_modele.cfg`

Super boulot !